### PR TITLE
Open dev-master 8.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Ultra easy-to-use [`RabbitMQ`](https://www.rabbitmq.com/) implementation for [`N
 
 | State  | Version      | Branch   | Nette  | PHP     |
 |--------|--------------|----------|--------|---------|
-| stable | `^6.0.0`     | `master` | `3.0+` | `^7.4`  |
+| dev    | `^8.0.0`     | `master` | `3.0+` | `^7.4`  |
+| stable | `^7.0.0`     | `master` | `3.0+` | `^7.4`  |
 
 ## Maintainers
 

--- a/composer.json
+++ b/composer.json
@@ -39,5 +39,10 @@
 		"phpstan": "vendor/bin/phpstan analyse src -c vendor/gamee/php-code-checker-rules/phpstan.neon --level 7",
 		"phpcs": "vendor/bin/phpcs --standard=vendor/gamee/php-code-checker-rules/ruleset.xml --extensions=php,phpt --tab-width=4 --ignore=temp -sp src",
 		"phpcsfix": "vendor/bin/phpcbf --standard=vendor/gamee/php-code-checker-rules/ruleset.xml --extensions=php,phpt --tab-width=4 --ignore=temp -sp src"
+	},
+	"extra": {
+		"branch-alias": {
+			"dev-master": "8.0.x-dev"
+		}
 	}
 }


### PR DESCRIPTION
When there is a need for testing new vendor verions and we don't want to use `dev-master`, let's use a branch-alias.