### PR TITLE
Added support for `MESSAGE_ACK_AND_TERMINATE`

### DIFF
--- a/src/Consumer/Consumer.php
+++ b/src/Consumer/Consumer.php
@@ -88,6 +88,13 @@ final class Consumer
 
 						break;
 
+					case IConsumer::MESSAGE_ACK_AND_TERMINATE:
+						// Acknowledge message and terminate
+						$channel->ack($message);
+						$client->stop();
+
+						break;
+
 					default:
 						throw new \InvalidArgumentException(
 							"Unknown return value of consumer [{$this->name}] user callback"

--- a/src/Consumer/IConsumer.php
+++ b/src/Consumer/IConsumer.php
@@ -13,6 +13,7 @@ interface IConsumer
 	public const MESSAGE_NACK = 2;
 	public const MESSAGE_REJECT = 3;
 	public const MESSAGE_REJECT_AND_TERMINATE = 4;
+	public const MESSAGE_ACK_AND_TERMINATE = 5;
 
 	public function consume(Message $message): int;
 


### PR DESCRIPTION
Limiting the consumer by the number of messages or number of seconds is not ideal in my use case

we want for the consumer to run for a fixed amount of time, eg 1 hour but we cannot afford to kill the consumer after given time of seconds due to the way we process the items - depending on the traffix we're queuing the messages inside the consumer and we're processing them in batches.

Having the option `ACK_TERMINATE` will allow us to kill the consumer whenever we want to