### PR TITLE
Support for heartbeat in Producer

### DIFF
--- a/src/Connection/Client.php
+++ b/src/Connection/Client.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Contributte\RabbitMQ\Connection;
+
+use Bunny\Client as BunnyClient;
+use Bunny\Exception\BunnyException;
+use Bunny\Protocol\HeartbeatFrame;
+
+class Client extends BunnyClient
+{
+	/**
+	 * @throws BunnyException
+	 */
+	public function sendHeartbeat(): void {
+		$this->getWriter()->appendFrame(new HeartbeatFrame(), $this->writeBuffer);
+		$this->flushWriteBuffer();
+	}
+}

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -11,11 +11,9 @@ use Contributte\RabbitMQ\Connection\Exception\ConnectionException;
 final class Connection implements IConnection
 {
 
-	private Client $bunnyClient;
+	private const HEARTBEAT_INTERVAL = 1;
 
-	/**
-	 * @var array
-	 */
+	private Client $bunnyClient;
 	private array $connectionParams;
 	private int $lastBeat = 0;
 	private ?Channel $channel = null;
@@ -114,14 +112,10 @@ final class Connection implements IConnection
 	}
 
 
-	public function heartbeat(): void
+	public function sendHeartbeat(): void
 	{
-		if ($this->connectionParams['heartbeat'] && $this->bunnyClient->isConnected()) {
-			$now = time();
-			if ($this->lastBeat > ($now - (int) $this->connectionParams['heartbeat'])) {
-				return;
-			}
-
+		$now = time();
+		if ($this->lastBeat < ($now - self::HEARTBEAT_INTERVAL) && $this->bunnyClient->isConnected()) {
 			$this->bunnyClient->sendHeartbeat();
 			$this->lastBeat = $now;
 		}

--- a/src/Connection/IConnection.php
+++ b/src/Connection/IConnection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Contributte\RabbitMQ\Connection;
 
 use Bunny\Channel;
+use Bunny\Exception\BunnyException;
 use Contributte\RabbitMQ\Connection\Exception\ConnectionException;
 
 interface IConnection
@@ -14,4 +15,9 @@ interface IConnection
 	 * @throws ConnectionException
 	 */
 	public function getChannel(): Channel;
+
+	/**
+	 * @throws BunnyException
+	 */
+	public function heartbeat(): void;
 }

--- a/src/Connection/IConnection.php
+++ b/src/Connection/IConnection.php
@@ -19,5 +19,5 @@ interface IConnection
 	/**
 	 * @throws BunnyException
 	 */
-	public function heartbeat(): void;
+	public function sendHeartbeat(): void;
 }

--- a/src/Producer/Producer.php
+++ b/src/Producer/Producer.php
@@ -61,13 +61,13 @@ final class Producer
 	}
 
 
-	public function heartbeat(): void
+	public function sendHeartbeat(): void
 	{
 		if ($this->queue !== null) {
-			$this->queue->getConnection()->heartbeat();
+			$this->queue->getConnection()->sendHeartbeat();
 		}
 		if ($this->exchange !== null) {
-			$this->exchange->getConnection()->heartbeat();
+			$this->exchange->getConnection()->sendHeartbeat();
 		}
 	}
 

--- a/src/Producer/Producer.php
+++ b/src/Producer/Producer.php
@@ -61,6 +61,17 @@ final class Producer
 	}
 
 
+	public function heartbeat(): void
+	{
+		if ($this->queue !== null) {
+			$this->queue->getConnection()->heartbeat();
+		}
+		if ($this->exchange !== null) {
+			$this->exchange->getConnection()->heartbeat();
+		}
+	}
+
+
 	private function getBasicHeaders(): array
 	{
 		return [


### PR DESCRIPTION
Bunny does not support producers from CLI well (producers that run long time, but send message only once a long period). So producers often drop connection in middle, but bunny have no idea about it (stream is closed) and if you try write data, it will end badly.

This commit add new option, so you can send heartbeat to the connection, and if needed, it will publish them to the rabbit, so connection will not close and we will all live happy life.

Drawback: you must call heartbeat by yourself, app cant do it for you