### PR TITLE
Add sync disconnect

### DIFF
--- a/src/Connection/Client.php
+++ b/src/Connection/Client.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Contributte\RabbitMQ\Connection;
 
 use Bunny\Client as BunnyClient;
+use Bunny\ClientStateEnum;
 use Bunny\Exception\BunnyException;
+use Bunny\Exception\ClientException;
 use Bunny\Protocol\HeartbeatFrame;
 
 class Client extends BunnyClient
@@ -16,5 +18,32 @@ class Client extends BunnyClient
 	public function sendHeartbeat(): void {
 		$this->getWriter()->appendFrame(new HeartbeatFrame(), $this->writeBuffer);
 		$this->flushWriteBuffer();
+	}
+
+	public function syncDisconnect(): bool
+	{
+		try {
+			if ($this->state !== ClientStateEnum::CONNECTED) {
+				return false;
+			}
+
+			$this->state = ClientStateEnum::DISCONNECTING;
+
+			foreach ($this->channels as $channel) {
+				$channelId = $channel->getChannelId();
+
+				$this->channelClose($channelId, 0, '', 0, 0);
+				$this->removeChannel($channelId);
+			}
+
+			$this->connectionClose(0, '', 0, 0);
+			$this->closeStream();
+		} catch (ClientException $e) {
+			// swallow, we do not care we are not connected, we want to close connection anyway
+		}
+
+		$this->init();
+		
+		return true;
 	}
 }

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -56,7 +56,7 @@ final class Connection implements IConnection
 	public function __destruct()
 	{
 		if ($this->bunnyClient->isConnected()) {
-			$this->bunnyClient->disconnect();
+			$this->bunnyClient->syncDisconnect();
 		}
 	}
 


### PR DESCRIPTION
Sync disconnect without Promises. The main reason for this is, that client itself is sync (async is in async/client.php) and if connection is lost during app run, it will end fatal error with exception, that can`t be catch. This will put the disconnect back to the sync state, so no more promise and no mo trouble if connection is dropped.