### PR TITLE
Better error message for consumer command

### DIFF
--- a/src/Console/Command/AbstractConsumerCommand.php
+++ b/src/Console/Command/AbstractConsumerCommand.php
@@ -35,8 +35,8 @@ abstract class AbstractConsumerCommand extends Command
 
 		} catch (ConsumerFactoryException $e) {
 			throw new \InvalidArgumentException(
-				sprintf(
-					"Consumer [$consumerName] does not exist. \n\n Available consumers: %s",
+				$e->getMessage() . sprintf(
+					"\n\n Available consumers: %s",
 					implode('', array_map(static function($s): string {
 						return "\n\t- [{$s}]";
 					}, $this->consumersDataBag->getDataKeys()))


### PR DESCRIPTION
The previous version assumes that the only possible reason for the exception is that the consumer does not exist.

Just by cursory a look, this is already not the case - you can have the exception in the case the callback is not callable.

Also, this is "future-proofing" for other possible reasons you might not be able to create the consumer.