### PR TITLE
Add possibility to have more routing keys for one exchange

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -52,7 +52,11 @@ rabbitmq:
 			type: fanout
 			queueBindings:
 				testQueue:
+					# use only one option from `routingKey` and `routingKeys`, otherwise an exception will be thrown
 					routingKey: testRoutingKey
+					# routingKeys:
+						# - testRoutingKey1
+						# - testRoutingKey2
 			# force exchange declare on first exchange operation during request
 			# autoCreate: true
 
@@ -160,14 +164,14 @@ final class LongRunningTestQueue
 	 * @var Producer
 	 */
 	private $testProducer;
-	
+
 	/**
-     * @var DataProvider Some data provider 
+     * @var DataProvider Some data provider
      */
 	private $dataProvider;
-	
+
 	/**
-     * @var bool 
+     * @var bool
      */
 	private $running;
 
@@ -177,7 +181,7 @@ final class LongRunningTestQueue
 		$this->testProducer = $testProducer;
 		$this->dataProvider = $dataProvider;
 	}
-	
+
 	public function run(): void {
 	    do {
 	        $message = $this->dataProvider->getMessage();
@@ -185,7 +189,7 @@ final class LongRunningTestQueue
 	            $this->testProducer->sendHeartbeat();
 	            continue;
 	        }
-	        
+
 	        $this->publish($message);
 	    } while ($this->running);
 	}
@@ -265,16 +269,16 @@ final class TestConsumer
 		foreach($messages as $message) {
 			$data[$message->deliveryTag] = json_decode($message->content);
 		}
-		
+
 		/**
 		 * @todo bulk message action
-		 */ 
-		 
+		 */
+
 		 foreach(array_keys($data) as $tag) {
 			$return[$tag] = IConsumer::MESSAGE_ACK; // Or ::MESSAGE_NACK || ::MESSAGE_REJECT
 		 }
-		
-		return $return; 
+
+		return $return;
 	}
 
 }

--- a/src/DI/Helpers/ExchangesHelper.php
+++ b/src/DI/Helpers/ExchangesHelper.php
@@ -38,6 +38,7 @@ final class ExchangesHelper extends AbstractHelper
 	 */
 	private array $queueBindingDefaults = [
 		'routingKey' => '',
+		'routingKeys' => [],
 		'noWait' => false,
 		'arguments' => [],
 	];
@@ -67,12 +68,21 @@ final class ExchangesHelper extends AbstractHelper
 
 			if ($exchangeConfig['queueBindings'] !== []) {
 				foreach ($exchangeConfig['queueBindings'] as $queueName => $queueBindingData) {
-					$queueBindingData['routingKey'] = (string) $queueBindingData['routingKey'];
+					if (isset($queueBindingData['routingKey']) && isset($queueBindingData['routingKeys'])) {
+						throw new \InvalidArgumentException(
+							"Options `routingKey` and `routingKeys` cannot be specified at the same time"
+						);
+					}
 
-					$exchangeConfig['queueBindings'][$queueName] = $this->extension->validateConfig(
+					$queueBindingConfig = $this->extension->validateConfig(
 						$this->queueBindingDefaults,
 						$queueBindingData
 					);
+
+					$queueBindingConfig['routingKey'] = (string) $queueBindingConfig['routingKey'];
+					$queueBindingConfig['routingKeys'] = array_map('strval', (array) $queueBindingConfig['routingKeys']);
+
+					$exchangeConfig['queueBindings'][$queueName] = $queueBindingConfig;
 				}
 			}
 

--- a/src/Exchange/ExchangeDeclarator.php
+++ b/src/Exchange/ExchangeDeclarator.php
@@ -52,14 +52,22 @@ final class ExchangeDeclarator
 		if ($exchangeData['queueBindings'] !== []) {
 			foreach ($exchangeData['queueBindings'] as $queueName => $queueBinding) {
 				$queue = $this->queueFactory->getQueue($queueName);
+				
+				if ($queueBinding['routingKeys'] !== []) {
+					$routingKeysToBind = $queueBinding['routingKeys'];
+				} else {
+					$routingKeysToBind = [$queueBinding['routingKey']];
+				}
 
-				$connection->getChannel()->queueBind(
-					$queue->getName(),
-					$name,
-					$queueBinding['routingKey'],
-					$queueBinding['noWait'],
-					$queueBinding['arguments']
-				);
+				foreach ($routingKeysToBind as $routingKey) {
+					$connection->getChannel()->queueBind(
+						$queue->getName(),
+						$name,
+						$routingKey,
+						$queueBinding['noWait'],
+						$queueBinding['arguments']
+					);
+				}
 			}
 		}
 	}

--- a/src/Exchange/ExchangeFactory.php
+++ b/src/Exchange/ExchangeFactory.php
@@ -78,7 +78,8 @@ final class ExchangeFactory
 
 				$queueBindings[] = new QueueBinding(
 					$queue,
-					$queueBinding['routingKey']
+					$queueBinding['routingKey'],
+					...$queueBinding['routingKeys']
 				);
 			}
 		}

--- a/src/Exchange/QueueBinding.php
+++ b/src/Exchange/QueueBinding.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Contributte\RabbitMQ\Exchange;
 
+use Contributte\RabbitMQ\Exchange\Exception\QueueBindingException;
 use Contributte\RabbitMQ\Queue\IQueue;
 
 final class QueueBinding
@@ -11,14 +12,17 @@ final class QueueBinding
 
 	private IQueue $queue;
 	private string $routingKey;
+	private array $routingKeys;
 
 
 	public function __construct(
 		IQueue $queue,
-		string $routingKey
+		string $routingKey,
+		string ...$routingKeys
 	) {
 		$this->queue = $queue;
 		$this->routingKey = $routingKey;
+		$this->routingKeys = $routingKeys;
 	}
 
 
@@ -31,5 +35,11 @@ final class QueueBinding
 	public function getRoutingKey(): string
 	{
 		return $this->routingKey;
+	}
+
+
+	public function getRoutingKeys(): array
+	{
+		return $this->routingKeys;
 	}
 }


### PR DESCRIPTION
This PR is dealing with issue https://github.com/contributte/rabbitmq/issues/59 and add possibility to have more routing keys for one exchange.

Configuration can looks like this:
```neon
rabbitmq:
	exchanges:
		testExchange:
			connection: default
			type: direct
			queueBindings:
				testQueue:
					routingKeys:
						- key1
						- key2
```

But it is still possible to use it like before:
```neon
rabbitmq:
	exchanges:
		testExchange:
			connection: default
			type: direct
			queueBindings:
				testQueue:
					routingKey: key1
```

cc @f3l1x @paveljanda 