### PR TITLE
fix: issue #64 - undefined array key 'routingKeys'

### DIFF
--- a/src/Exchange/ExchangeFactory.php
+++ b/src/Exchange/ExchangeFactory.php
@@ -79,7 +79,7 @@ final class ExchangeFactory
 				$queueBindings[] = new QueueBinding(
 					$queue,
 					$queueBinding['routingKey'],
-					...$queueBinding['routingKeys']
+					...$queueBinding['routingKeys'] ?? []
 				);
 			}
 		}


### PR DESCRIPTION
Undefined array key 'routingKeys' leads to TypeError in unpacking operator (only arrays can be unpacked).

Closes #64